### PR TITLE
Correct an old topic name

### DIFF
--- a/src/software-management/thin-edge-json-mapping-to-from-c8y.md
+++ b/src/software-management/thin-edge-json-mapping-to-from-c8y.md
@@ -139,7 +139,7 @@ There are rules how to convert from SmartREST to ThinEdgeJSON.
 3. If the `URL` field is empty or a " " (space), mapper considers that the package should be installed from the standard repository.
 
 
-Then, the translated Thin Edge JSON goes on the topic `tedge/inbound/software/update` to SM Agent.
+Then, the translated Thin Edge JSON goes on the topic `tedge/commands/req/software/update` to SM Agent.
 
 ```json
 {


### PR DESCRIPTION
One sentence still mentions "tedge/inbound/software/update". This topic is replaced by "tedge/commands/req/software/update".