### PR TITLE
Remove reference to supporting a raw alarm format

### DIFF
--- a/src/alarms/alarm-handling.md
+++ b/src/alarms/alarm-handling.md
@@ -77,22 +77,3 @@ tedge mqtt sub "tedge/alarms/+/+/upper-limit-exceeded"
 
 # And for sure all combinations.
 ```
-
-
-Additionally an also supported "raw"-payload format will allow easy adoption for existing "MQTT publishers":
-
-**Raw payload format:**
-```
-Topic:   tedge/alarms/<severity-string>/<type-string>
-Payload: <text-string>
-```
-
-NOTE: Child-device addressing works in the same way as for the JSON payload format above.
-
-In raw format for missing fields default values are used as below: 
-   - "status" := "ACTIVE", if payload is not empty; "CLEARED", if payload empty<br/>
-     NOTE: By nature of MQTT a message with empty payload will not be retained by the broker. However the mapper will store already transferred messages for de-duplication purpose anyway (see requirements above). Using that information mapper is in case of restart able to detect any not yet sent empty message.
-   - "time" := set to current system-time when picked-up by mapper
-
-Benefit to support "raw payload format":
-In industrial area (e.g. PLCs) there exist configurable MQTT publishers. These pick-up some data-item (e.g. some process-datapoint, alarm, ...) and publish it's raw value to some configured MQTT topic. With "raw payload format" above, such MQTT publishers can use thin-edge alarm interface without coding/developing some component in between.


### PR DESCRIPTION
The raw alarm payload format was never supported by thin-edge.io and is being removed from the spec to avoid future confusion.